### PR TITLE
階乗関数のトホホな実装例

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,9 +5,12 @@
 * @param {Number} n
 * @returns {Number}
 */
+const n=process.argv[2] || 1;
 function factorial(n) {
     let result = 1;
-    // TODO このコメントを消して正しく実装してください。
+    for (let i=1; i<=n; i++){
+        result=result*i;  
+    }
     return result;
 }
 const assert = require('assert');


### PR DESCRIPTION
「すべてのテストを通過しました」と表示されたので、喜んでpushしたものの、解答例をみて唖然。
プログラム後半のテストケースで引数が与えられるのだから、「 const n = process.argv[2] || 1 ; 」とか不要でした。
じゃあどうしてnをconstにしたのに、テストケースで再代入されているんだ？で調べたら、どこかのサイトに、関数の外に引数と同じ名前の変数があったとしても、それは全く別の変数として扱われる、といった記述がありました。
確かに、const nは生きていて、プログラムの最後に「console.log( factorial( n ) ) ;」と入れるとコマンドラインからの入力にもちゃんと答えを出します。面白いですね。